### PR TITLE
Chore/update to 3.1.0+9.0

### DIFF
--- a/.github/workflows/test_installer.yml
+++ b/.github/workflows/test_installer.yml
@@ -45,10 +45,10 @@ jobs:
           # Example: check if 'coq-lsp.exe' is running
           ls
           ls C:\
-          C:\waterproof_dependencies\opam\wp-3.0.0+9.0\bin\coq-lsp.exe --version
+          C:\waterproof_dependencies\opam\wp-3.1.0+9.0\bin\coq-lsp.exe --version
         shell: pwsh
 
       - name: Confirm dll exists in directory
         run: |
-          Test-Path "C:\waterproof_dependencies\opam\wp-3.0.0+9.0\bin\libgmp-10.dll"
+          Test-Path "C:\waterproof_dependencies\opam\wp-3.1.0+9.0\bin\libgmp-10.dll"
         shell: pwsh

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,7 +12,6 @@ on:
   push:
     branches:
       - main
-      - "chore/update-to-3.1.0+9.0"
       # - test-installer
   pull_request:
   workflow_dispatch:
@@ -48,7 +47,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: main
-          ref: "chore/update-to-3.1.0+9.0"
+          ref: main
 
       - name: Some steps for debugging
         shell: cmd

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: main
-          ref: main
+          ref: "chore/update-to-3.1.0+9.0"
 
       - name: Some steps for debugging
         shell: cmd

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Include custom .nsh script before all install sections
         shell: cmd
         run: |
-          sed -i 's/;Installer Sections/;Installer Sections\\\n\\\n!include "before-sections.nsh"/g' platform/windows/Coq.nsi
+          sed -i 's/;Installer Sections/;Installer Sections\n\n!include "before_sections.nsh"\n\n/g' platform/windows/Coq.nsi
           cat platform/windows/Coq.nsi
 
       - name: Link shared coq-lsp libraries

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,12 +6,13 @@ name: Windows
 
 ###############################################################################
 # Schedule:
-# Workflow runs on pushes to main and to waterproof_3.0.0+9.0 branch
+# Workflow runs on pushes to main and to waterproof_3.1.0+9.0 branch
 ###############################################################################
 on:
   push:
     branches:
       - main
+      - "chore/update-to-3.1.0+9.0"
       # - test-installer
   pull_request:
   workflow_dispatch:
@@ -21,7 +22,7 @@ on:
 ###############################################################################
 env:
   COQREGTESTING: y
-  SWITCH_NAME: wp-3.0.0+9.0
+  SWITCH_NAME: wp-3.1.0+9.0
 
 ###############################################################################
 # Builds Windows installer
@@ -178,13 +179,13 @@ jobs:
       #   if: always()
       #   shell: cmd
       #   run: |
-      #     C:\waterproof_dependencies\bin\bash --login -c "opam install -y coq-lsp.0.2.3+9.0"
+      #     C:\waterproof_dependencies\bin\bash --login -c "opam install -y coq-lsp.0.2.4+9.0"
 
       - name: Install coq-waterproof
         if: always()
         shell: cmd
         run: |
-          C:\waterproof_dependencies\bin\bash --login -c "opam pin add -y https://github.com/impermeable/coq-waterproof.git#3.0.0+9.0"
+          C:\waterproof_dependencies\bin\bash --login -c "opam pin add -y https://github.com/impermeable/coq-waterproof.git#3.1.0+9.0-pre"
 
       # - name: Create installer - comment out coqide
       #   if: always()

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -90,13 +90,14 @@ jobs:
           sed -i 's/\s\sInstallDir\s"C:\\\${MY_PRODUCT}"/  InstallDir "C:\\\waterproof_dependencies\\\opam\\\${{ env.SWITCH_NAME }}"/g' platform/windows/Coq.nsi
           cat platform/windows/Coq.nsi
 
-      - name: Copy platform pick script and icon to right place
+      - name: Copy platform pick script, icon, and before-section script to right place
         shell: cmd
         run : |
           cat main\package-pick-${{ env.SWITCH_NAME }}.sh
           dir platform
           dir platform\package_picks
           copy "main\package-pick-${{ env.SWITCH_NAME }}.sh" "platform\package_picks\package-pick-${{ env.SWITCH_NAME }}.sh"
+          copy "main\before_sections.nsh" "platform\windows\before_sections.nsh"
 
       - name: Missing dependency
         shell: cmd
@@ -130,6 +131,12 @@ jobs:
           sed -i 's/!define MUI_DIRECTORYPAGE_TEXT_TOP/!define MUI_DIRECTORYPAGE_TEXT_TOP "Please note:\$\\\r\$\\\n- Waterproof works best if you **do not change the folder below**.\$\\\r\$\\\n- If you do change the folder, please make a note of what you set it to.\$\\\r\$\\\n- The path to the folder may not include spaces.\$\\\r\$\\\n- If you have installed Waterproof dependency software in the same folder before, please remove it through add or remove programs in Windows.\$\\\r\$\\\n- It is fine to install different versions of the software in different folders."\n;!define MUI_DIRECTORYPAGE_TEXT_TOP/g' platform/windows/Coq.nsi
           sed -i 's$\"Publisher\" \"The Coq Team\"$\"Publisher\" \"The Waterproof Team\"$g' platform/windows/Coq.nsi
           sed -i 's$  !insertmacro MUI_PAGE_COMPONENTS$  !define MUI_COMPONENTSPAGE_TEXT_TOP \"Waterproof needs all the components below in order to work.\"\n  !insertmacro MUI_PAGE_COMPONENTS$g' platform/windows/Coq.nsi
+          cat platform/windows/Coq.nsi
+
+      - name: Include custom .nsh script before all install sections
+        shell: cmd
+        run: |
+          sed -i 's/;Installer Sections/;Installer Sections\\\n\\\n!include "before-sections.nsh"/g' platform/windows/Coq.nsi
           cat platform/windows/Coq.nsi
 
       - name: Link shared coq-lsp libraries

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 In the intended usage, the installer is downloaded and executed automatically from the vscode extension.
 Alternatively, it can be downloaded manually.
 
-⚠ Note that the installation path should be chosen to be `C:\waterproof_dependencies\opam\wp-3.0.0+9.0\`
+⚠ Note that the installation path should be chosen to be `C:\waterproof_dependencies\opam\wp-3.1.0+9.0\`
 
 ⚠ Note that in the library selection window, all selected libraries are necessary for Waterproof to function
 

--- a/before_sections.nsh
+++ b/before_sections.nsh
@@ -1,8 +1,11 @@
+!include "StrRep.nsh"
+
 Section "BeforeSections" SEC_BeforeSections
   SetOutPath "$INSTDIR\bin\"
+  !insertmacro StrRep $8 "path=$\"$INSTDIR\lib$\"$\r$\n" "\" "\\"
   Push $9
   FileOpen $9 "$INSTDIR\bin\findlib.conf" w
-  FileWrite $9 "path=$\"$INSTDIR\lib$\"$\r$\n"
+  FileWrite $9 $8
   FileClose $9
   Pop $9
 SectionEnd

--- a/before_sections.nsh
+++ b/before_sections.nsh
@@ -2,7 +2,7 @@ Section "BeforeSections" SEC_BeforeSections
   SetOutPath "$INSTDIR\bin\"
   Push $9
   FileOpen $9 "$INSTDIR\bin\findlib.conf" w
-  FileWrite $9 "path=\"$INSTDIR\\\\lib\"$\r$\n"
+  FileWrite $9 "path=$\"$INSTDIR\lib$\"$\r$\n"
   FileClose $9
   Pop $9
 SectionEnd

--- a/before_sections.nsh
+++ b/before_sections.nsh
@@ -1,0 +1,8 @@
+Section "BeforeSections" SEC_BeforeSections
+  SetOutPath "$INSTDIR\bin\"
+  Push $9
+  FileOpen $9 "$INSTDIR\bin\findlib.conf" w
+  FileWrite $9 "path=\"$INSTDIR\\\\lib\"$\r$\n"
+  FileClose $9
+  Pop $9
+SectionEnd

--- a/package-pick-wp-3.1.0+9.0.sh
+++ b/package-pick-wp-3.1.0+9.0.sh
@@ -18,7 +18,7 @@ COQ_PLATFORM_VERSION_SORTORDER=1
 # It is usually either empty ot starts with ~.
 # It might also be used for installer package names, but with ~ replaced by _
 # It is also used for version specific file selections in the smoke test kit.
-COQ_PLATFORM_PACKAGE_PICK_POSTFIX='wp-3.0.0+9.0'
+COQ_PLATFORM_PACKAGE_PICK_POSTFIX='wp-3.1.0+9.0'
 
 # The corresponding Coq development branch and tag
 COQ_PLATFORM_COQ_BRANCH="v9.0"
@@ -53,7 +53,7 @@ PACKAGES="${PACKAGES} PIN.ocamlfind.1.9.5~relocatable"  # TODO port patch to 1.9
 PACKAGES="${PACKAGES} PIN.dune-configurator.3.19.1"
 # The Coq compiler coqc and the Coq standard library
 PACKAGES="${PACKAGES} PIN.rocq-prover.9.0.0"
-PACKAGES="${PACKAGES} coq-lsp.0.2.3+9.0"
+PACKAGES="${PACKAGES} coq-lsp.0.2.4+9.0"
 
 # For now include rocqide, although eventually we would like to remove this
 PACKAGES="${PACKAGES} rocqide.9.0.0"

--- a/package-pick-wp-3.1.0+9.0.sh
+++ b/package-pick-wp-3.1.0+9.0.sh
@@ -47,7 +47,7 @@ PACKAGES=""
 ########## BASE PACKAGES ##########
 
 # Coq needs a patched ocamlfind to be relocatable by installers
-PACKAGES="${PACKAGES} PIN.ocamlfind.1.9.5~relocatable"  # TODO port patch to 1.9.6
+PACKAGES="${PACKAGES} PIN.ocamlfind.1.9.8"  # TODO port patch to 1.9.6
 # Since dune does support Coq, it is explicitly selected
 #PACKAGES="${PACKAGES} PIN.dune.3.16.1" # 3.17.2 has issues on Windows: cairo doesn't find cairo.h
 PACKAGES="${PACKAGES} PIN.dune-configurator.3.19.1"


### PR DESCRIPTION
Updates to a prerelease version for Waterproof 3.1.0+9.0

Coq-lsp is updated to 0.2.4. This forces the dependency of ocamlfind to go up in version number to 1.9.8. This seems not directly supported in the Rocq platform, but a workaround seems to be to set the `OCAMLFIND_CONF` environment variable in a later stage. To this end, we let the installer create a custom file `findlib.conf` with information on the installed location.